### PR TITLE
fix: preview table styling to take full width of parent container

### DIFF
--- a/app/views/Data/Workspace/ImportTable/PreviewTable/index.tsx
+++ b/app/views/Data/Workspace/ImportTable/PreviewTable/index.tsx
@@ -50,7 +50,7 @@ export default function ImportTable(props: Props) {
 
     return (
         <Paper className={styles.tableContainer} radius="md" withBorder>
-            <ScrollArea>
+            <ScrollArea className={styles.scrollArea}>
                 <Table striped withColumnBorders>
                     <thead>
                         <tr>

--- a/app/views/Data/Workspace/ImportTable/PreviewTable/styles.module.css
+++ b/app/views/Data/Workspace/ImportTable/PreviewTable/styles.module.css
@@ -2,4 +2,9 @@
     display: flex;
     flex-grow: 1;
     overflow: auto;
+
+    .scroll-area {
+        display: flex;
+        flex-grow: 1;
+    }
 }

--- a/app/views/Data/Workspace/ImportTable/TablePropertiesForm/index.tsx
+++ b/app/views/Data/Workspace/ImportTable/TablePropertiesForm/index.tsx
@@ -10,6 +10,7 @@ import {
     Title,
     LoadingOverlay,
     ScrollArea,
+    SelectItem,
 } from '@mantine/core';
 import { useMutation } from 'urql';
 import { IoChevronDown } from 'react-icons/io5';
@@ -184,14 +185,14 @@ export default function TablePropertiesForm(props: Props) {
                 >
                     <Select
                         label="Header Levels"
-                        data={options?.headerLevels}
+                        data={options?.headerLevels as SelectItem[]} // TODO: fix types in server
                         rightSection={<IoChevronDown className={styles.icon} />}
                         styles={{ rightSection: { pointerEvents: 'none' } }}
                         {...tablePropertiesForm.getInputProps('headerLevel')}
                     />
                     <Select
                         label="Time Zone (Optional)"
-                        data={options?.timezones}
+                        data={options?.timezones as SelectItem[]} // TODO: fix types in server
                         rightSection={<IoChevronDown className={styles.icon} />}
                         styles={{ rightSection: { pointerEvents: 'none' } }}
                         {...tablePropertiesForm.getInputProps('timezone')}
@@ -210,7 +211,7 @@ export default function TablePropertiesForm(props: Props) {
                         rightSection={<IoChevronDown className={styles.icon} />}
                         rightSectionWidth={30}
                         styles={{ rightSection: { pointerEvents: 'none' } }}
-                        data={options?.languages}
+                        data={options?.languages as SelectItem[]} // TODO: fix types in server
                         {...tablePropertiesForm.getInputProps('language')}
                     />
                     <Group position="apart">

--- a/schema.graphql
+++ b/schema.graphql
@@ -313,7 +313,7 @@ input TablePropertiesInputType {
   headerLevel: String!
   language: String!
   timezone: String!
-  treatTheseAsNa: String
+  treatTheseAsNa: String!
   trimWhitespaces: Boolean!
 }
 


### PR DESCRIPTION
Fixes https://github.com/the-dive/dive-client/issues/77

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
