### PR TITLE
FIX: Modal size resize and summary stats location change

### DIFF
--- a/app/components/TableWithStatusBar/index.tsx
+++ b/app/components/TableWithStatusBar/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 import {
     ActionIcon,
     Paper,
@@ -6,10 +6,10 @@ import {
     ScrollArea,
     Collapse,
     SegmentedControl,
-    Flex,
     Tabs,
     Text,
     SimpleGrid,
+    Group,
 } from '@mantine/core';
 import { useToggle } from '@mantine/hooks';
 import { IoChevronDown, IoChevronUp } from 'react-icons/io5';
@@ -40,7 +40,9 @@ export default function TableWithStatusBar(props: Props) {
         rows,
         card,
     } = props;
+
     const [opened, toggleOpened] = useToggle([true, false]);
+    const [activeTab, setActiveTab] = useState<string | null>('tableView');
 
     const handleCollapseClick = useCallback(() => {
         toggleOpened();
@@ -56,13 +58,18 @@ export default function TableWithStatusBar(props: Props) {
             >
                 <Tabs
                     variant="pills"
-                    defaultValue="tableView"
+                    value={activeTab}
+                    onTabChange={setActiveTab}
                     className={styles.tab}
                 >
-                    <Tabs.List>
-                        <Tabs.Tab value="tableView" icon={<MdOutlineTableChart size={14} />} />
-                        <Tabs.Tab value="listView" icon={<MdList size={14} />} />
-                        <Tabs.Tab value="gridView" icon={<MdOutlineGridView size={14} />} />
+                    <Tabs.List
+                        className={styles.tabList}
+                    >
+                        <Group>
+                            <Tabs.Tab value="tableView" icon={<MdOutlineTableChart size={14} />} />
+                            <Tabs.Tab value="listView" icon={<MdList size={14} />} />
+                            <Tabs.Tab value="gridView" icon={<MdOutlineGridView size={14} />} />
+                        </Group>
                         {/* NOTE: Add these component after implementation of columns type count
                         <Group>
                             <ActionIcon
@@ -94,17 +101,30 @@ export default function TableWithStatusBar(props: Props) {
                                 <MdOutlineLocationOn />
                             </ActionIcon>
                         </Group> */}
-                        <ActionIcon
-                            color="dark"
-                            size="md"
-                            variant="transparent"
-                            onClick={handleCollapseClick}
-                        >
-                            {opened ? <IoChevronDown /> : <IoChevronUp />}
-                        </ActionIcon>
-                        <Text className={styles.stats}>
-                            {`${columns?.length} columns, ${rows?.length} rows`}
-                        </Text>
+                        {activeTab === 'listView' && (
+                            <SegmentedControl
+                                radius="lg"
+                                color="brand"
+                                size="xs"
+                                data={[
+                                    { value: 'summary_stats', label: 'Summary stats' },
+                                    { value: 'framework_setup', label: 'Framework setup', disabled: true },
+                                ]}
+                            />
+                        )}
+                        <Group>
+                            <Text className={styles.stats}>
+                                {`${columns?.length} columns, ${rows?.length} rows`}
+                            </Text>
+                            <ActionIcon
+                                color="dark"
+                                size="md"
+                                variant="transparent"
+                                onClick={handleCollapseClick}
+                            >
+                                {opened ? <IoChevronDown /> : <IoChevronUp />}
+                            </ActionIcon>
+                        </Group>
                     </Tabs.List>
                     <Collapse in={opened}>
                         <Tabs.Panel className={styles.tabPanelWrapper} value="tableView" pt="xs">
@@ -127,19 +147,6 @@ export default function TableWithStatusBar(props: Props) {
                         <Tabs.Panel className={styles.tabPanelWrapper} value="listView" pt="xs">
                             <Paper className={styles.tabPanel}>
                                 <ScrollArea className={styles.scrollArea}>
-                                    <Flex
-                                        justify="center"
-                                        p="sm"
-                                    >
-                                        <SegmentedControl
-                                            radius="lg"
-                                            color="brand"
-                                            data={[
-                                                { value: 'summary_stats', label: 'Summary stats' },
-                                                { value: 'framework_setup', label: 'Framework setup', disabled: true },
-                                            ]}
-                                        />
-                                    </Flex>
                                     <Table striped withColumnBorders>
                                         <thead>
                                             <tr>

--- a/app/components/TableWithStatusBar/index.tsx
+++ b/app/components/TableWithStatusBar/index.tsx
@@ -5,7 +5,6 @@ import {
     Table,
     ScrollArea,
     Collapse,
-    SegmentedControl,
     Tabs,
     Text,
     SimpleGrid,
@@ -102,15 +101,12 @@ export default function TableWithStatusBar(props: Props) {
                             </ActionIcon>
                         </Group> */}
                         {activeTab === 'listView' && (
-                            <SegmentedControl
-                                radius="lg"
-                                color="brand"
-                                size="xs"
-                                data={[
-                                    { value: 'summary_stats', label: 'Summary stats' },
-                                    { value: 'framework_setup', label: 'Framework setup', disabled: true },
-                                ]}
-                            />
+                            <Tabs>
+                                <Tabs.List defaultValue="first">
+                                    <Tabs.Tab value="first">Summary Stats</Tabs.Tab>
+                                    <Tabs.Tab disabled value="second">Framework Setup</Tabs.Tab>
+                                </Tabs.List>
+                            </Tabs>
                         )}
                         <Group>
                             <Text className={styles.stats}>

--- a/app/components/TableWithStatusBar/styles.module.css
+++ b/app/components/TableWithStatusBar/styles.module.css
@@ -6,10 +6,11 @@
 
     .tab {
         overflow: auto;
-
-        .stats {
-            margin-left: auto;
+        .tab-list {
+            display: flex;
+            justify-content: space-between;
         }
+
     }
 
     .table-status-button {

--- a/app/views/Data/Workspace/JoinModal/index.tsx
+++ b/app/views/Data/Workspace/JoinModal/index.tsx
@@ -184,7 +184,7 @@ export default function JoinModal(props: Props) {
                 </Title>
             )}
             radius="md"
-            size="80vw"
+            size="95vw"
             padding="md"
             centered
             classNames={{ body: styles.body }}


### PR DESCRIPTION
# Description
- Join Modal size increase
- Summary stats segment position change
- Summary stats changed into tabs

Fixes #119 
Fixes #125
Fixes #120 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
